### PR TITLE
update labels (see glottobank/grambank 1193)

### DIFF
--- a/src/pygrambank/cldf.py
+++ b/src/pygrambank/cldf.py
@@ -16,14 +16,11 @@ from pygrambank.util import iterunique
 INVALID = ['9', '.?']
 FEATURE_METADATA = [
     'Grambank_ID_desc',
-    'bound_morphology',
+    'boundness',
     'Flexivity',
     'Gender/noun class',
-    'HM/DM',
-    'HM DM Score for counting',
-    'OV vs VO types (excl affixes)',
-    'OV VO score for counting',
-    'OV vs VO types (incl affixation)',
+    'locus of marking',
+    'word order',
     'informativity',
 ]
 


### PR DESCRIPTION
I would like to change the names of three of the Theo-scores which are pulled into grambank-cldf parameters.csv (see [glottobank/grambank PR](https://github.com/glottobank/Grambank/pull/1193)) and not bring along categories which aren't used in the ms.

I thought that this would be an quick thing, but somehow this small change in cldf.py means I no longer can successfully run cldf.

I would really appreciate some help.

When I now run pygrambank's cldf, I get:

```
Traceback (most recent call last):
  File "/Users/skirgard/py_venvs/Grambank/bin/grambank", line 11, in <module>
    load_entry_point('pygrambank', 'console_scripts', 'grambank')()
  File "/Users/skirgard/py_venvs/Grambank/lib/python3.8/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/skirgard/py_venvs/Grambank/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/Users/skirgard/py_venvs/Grambank/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/Users/skirgard/py_venvs/Grambank/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/skirgard/Dropbox/Git/pygrambank/src/pygrambank/__init__.py", line 1, in <module>
    from pygrambank.api import Grambank  # noqa: F401
  File "/Users/skirgard/Dropbox/Git/pygrambank/src/pygrambank/api.py", line 10, in <module>
    from pygrambank.contributors import Contributors
  File "/Users/skirgard/Dropbox/Git/pygrambank/src/pygrambank/contributors.py", line 4, in <module>
    from clldutils.markup import iter_markdown_tables
ImportError: cannot import name 'iter_markdown_tables' from 'clldutils.markup' (/Users/skirgard/py_venvs/Grambank/lib/python3.8/site-packages/clldutils/markup.py)
```

When I last successfully ran pygrambank cldf, before any changes, I got this warning:

`WARNING Table without primary key: contributors.csv - This may cause problems with "cldf createdb"`
