### PR TITLE
Ignore (by default) legacy datasets in check.

### DIFF
--- a/src/pygrambank/commands/check.py
+++ b/src/pygrambank/commands/check.py
@@ -25,7 +25,21 @@ def register(parser):
         default=False,
         action='store_true',
     )
+    parser.add_argument(
+        '--legacy',
+        default=False,
+        action='store_true',
+    )
 
+
+def is_legacy(pathname):
+    """Returns True if pathname matches one of the legacy datasets"""
+    pathname = str(pathname)
+    for legacy in ['CB-PE-AS_', 'MD-GR-RSI_']:
+        if pathname.startswith(legacy):
+            return True
+    return False
+    
 
 def run(args):
     report, counts = [], {}
@@ -36,8 +50,11 @@ def run(args):
     else:
         sheets = [(s, list(s.itervalues(api))) for s in api.iter_sheets()]
         sheets = (s[0] for s in iterunique(sheets, verbose=args.verbose))
-
-    for sheet in sheets:
+    
+    for sheet in sorted(sheets, key=lambda s: s.path):
+        # filter out legacy datasets
+        if not args.filename and not args.legacy and is_legacy(sheet.path.stem):
+            continue
         n = sheet.check(api, report=report)
         if (sheet.glottocode not in counts) or (n > counts[sheet.glottocode][0]):
             counts[sheet.glottocode] = (n, sheet.path.stem)

--- a/src/pygrambank/commands/check.py
+++ b/src/pygrambank/commands/check.py
@@ -35,7 +35,7 @@ def register(parser):
 def is_legacy(pathname):
     """Returns True if pathname matches one of the legacy datasets"""
     pathname = str(pathname)
-    for legacy in ['CB-PE-AS_', 'MD-GR-RSI_']:
+    for legacy in ['CB-PE-AS_', 'MD-GR-RSI_', 'SD_']:
         if pathname.startswith(legacy):
             return True
     return False
@@ -48,13 +48,13 @@ def run(args):
     if args.filename:
         sheets = [Sheet(args.filename)]
     else:
-        sheets = [(s, list(s.itervalues(api))) for s in api.iter_sheets()]
+        sheets = [s for s in api.iter_sheets()]
+        if not args.legacy:  # filter out legacy datasets
+            sheets = [s for s in sheets if not is_legacy(s.path.stem)]
+        sheets = [(s, list(s.itervalues(api))) for s in sheets]
         sheets = (s[0] for s in iterunique(sheets, verbose=args.verbose))
     
     for sheet in sorted(sheets, key=lambda s: s.path):
-        # filter out legacy datasets
-        if not args.filename and not args.legacy and is_legacy(sheet.path.stem):
-            continue
         n = sheet.check(api, report=report)
         if (sheet.glottocode not in counts) or (n > counts[sheet.glottocode][0]):
             counts[sheet.glottocode] = (n, sheet.path.stem)


### PR DESCRIPTION
I find grambank `check` output overwhelming. This PR adds a `--legacy` flag to the `check` command that will filter the output. I wrote this to make it easier to see what new errors were lurking around as they are buried in the wall of output from CB-* and MD-*. 

Without this flag (the default) the errors from the legacy datasets are not reported cutting down output and runtime. 

With this flag, the `check` command functions as it has done, reporting errors on all sheets.


