### PR TITLE
add more exceptions to checking if comment contains "chceck"

### DIFF
--- a/src/pygrambank/sheet.py
+++ b/src/pygrambank/sheet.py
@@ -157,7 +157,12 @@ class Sheet(object):
                 log('source given, but no value', lineno=lineno, level='WARNING', row_=row)
             res = False
         if row['Comment']:
-            if re.search('check', row['Comment'].lower()) and not re.search('HG', row['Comment']):  
+            if re.search('check', row['Comment'].lower()) and \
+            not re.search('HG', row['Comment']) and \
+            not re.search('checked by coder', row['Comment'].lower()) and\
+            not re.search('check by coder', row['Comment'].lower()) and\
+            not re.search('wrong import', row['Comment'].lower()) and\
+            not re.search('checked by GB coder', row['Comment'].lower()):  
 #            if re.search('check', row['Comment'].lower()):
                 if log:  # pragma: no cover
                     log('comment contains string "check"', lineno=lineno, level='WARNING', row_=row)


### PR DESCRIPTION
There are exceptions that I want to exclude from getting the warning for comment string contains "check".