### PR TITLE
Few fixes

### DIFF
--- a/src/pygrambank/commands/check_encoding.py
+++ b/src/pygrambank/commands/check_encoding.py
@@ -64,7 +64,7 @@ def suggest_encodings(raw_line):
         try:
             suggestions[enc] = raw_line.decode(enc)
         except:  # pragma: nocover
-            pass
+            suggestions[enc] = '<could not decode from {}>'.format(enc)
     return suggestions
 
 
@@ -94,8 +94,8 @@ def run(args):
                 for match in find_non_ascii(raw_line):
                     print('{}:{}: Non-UTF8 character found: {}'.format(
                         p, lineno, repr(match)))
-                    for enc, res in sorted(suggest_encodings(raw_line).items()):
-                        print(' * {}:\t{}'.format(enc, res))
+                    for enc, res in sorted(suggest_encodings(match).items()):
+                        print(" * {}:\t'{}'".format(enc, res.rstrip('\r\n')))
 
         if utf8_detected and nonutf8_detected:
             print(

--- a/src/pygrambank/commands/recode.py
+++ b/src/pygrambank/commands/recode.py
@@ -2,6 +2,7 @@
 Recode a file, i.e. change its encoding to UTF-8.
 """
 from clldutils.clilib import PathType
+import sys
 
 
 def register(parser):
@@ -9,29 +10,73 @@ def register(parser):
     parser.add_argument(
         '--encoding',
         default='cp1252',
-        choices=['cp1252', 'macroman', 'mixed'],
+        choices=['cp1252', 'macroman', 'mixed-cp1252', 'mixed-macroman'],
     )
+
+
+def _split_into_nonascii(raw_line):
+    start = 0
+    found_non_ascii = False
+    for index, byte in enumerate(raw_line):
+        # non-ascii
+        if byte >= 0x80:
+            found_non_ascii = True
+        elif found_non_ascii:
+            yield raw_line[start:index]
+            found_non_ascii = False
+            start = index
+    if index > start:
+        yield raw_line[start:]
+
+
+def split_into_nonascii(raw_line):
+    return list(_split_into_nonascii(raw_line))
+
+
+def _decode_substring(raw_substring, enc):
+    try:
+        return raw_substring.decode('utf-8')
+    except:  # noqa: E722
+        try:
+            return raw_substring.decode(enc)
+        except:   # noqa: E722
+            return None
+
+
+def decode_mixed(raw_line, enc):
+    substrings = split_into_nonascii(raw_line)
+    unicode_strings = [_decode_substring(s, enc) for s in substrings]
+    if None in unicode_strings:
+        return None
+    else:
+        return ''.join(unicode_strings)
+
+
+def decode_line(raw_line, enc):
+    if enc.startswith('mixed-'):
+        return decode_mixed(raw_line, enc[6:])
+    else:
+        try:
+            return raw_line.decode(enc)
+        except:  # noqa: E722
+            return None
 
 
 def run(args):
     for p in args.path:
-        if args.encoding == 'mixed':
-            # Dunno how this happens, but sometimes, different lines are
-            # encoded differently ...
-            c = []
-            for line in p.read_bytes().split(b'\n'):
-                li = []
-                for chunk in line.split(b'\t'):
-                    try:
-                        li.append(chunk.decode('utf8'))
-                    except:  # noqa: E722
-                        try:
-                            li.append(chunk.decode('cp1252'))
-                        except:  # noqa: E722
-                            print(chunk)
-                            raise
-                c.append('\t'.join(li))
-            c = '\n'.join(c)
-        else:
-            c = p.read_text(encoding=args.encoding)
-        p.write_text(c, encoding='utf8')
+        with open(p, 'rb') as f:
+            raw_lines = [l.rstrip(b'\r\n') for l in f]
+
+        unicode_lines = [decode_line(l, args.encoding) for l in raw_lines]
+        found_invalid = False
+        for index, (line, raw_line) in enumerate(zip(unicode_lines, raw_lines)):
+            if line is None:
+                found_invalid = True
+                print(
+                    '{}:{}: Could not decode line:'.format(p, index + 1),
+                    repr(raw_line),
+                    file=sys.stderr)
+
+        if not found_invalid:
+            with open(p, 'w', encoding='utf-8') as f:
+                print('\n'.join(unicode_lines), file=f)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
 * Drop Python 3.6 from `tox.ini`

 * Tweaks to the output of `check_encoding`

 * `recode`: Support `utf8+macroman` as well as `utf8+cp1252` mixed encodings

 * `recode`: Try and resolve mixed encoding that happens *within* the same line
