### PR TITLE
support for `via` clause in citations (closes #71)

### DIFF
--- a/src/pygrambank/srctok.py
+++ b/src/pygrambank/srctok.py
@@ -64,6 +64,9 @@ def iter_ayps(s):
             continue
         condensed = False
         x = x.strip()
+        # In cases like `Author2 2011 via Author1 2012` only consider the bit
+        # after the `via`
+        x = re.split(r'\s+via\s+', x)[-1]
         m = refullsrc.search(x)
         if not m:
             m = resrc.search(x)

--- a/tests/repos/gb.bib
+++ b/tests/repos/gb.bib
@@ -29,6 +29,14 @@
     inlg = {en},
     year = {nd}
 }
+@book{book2022,
+    title = {The other book},
+    author = {The Author},
+    hhtype = {grammar},
+    inlg = {en},
+    lgcode = {[abc]},
+    year = {2022}
+}
 @book{multi_word_name_1,
     title = {The book on beta},
     author = {Last Name, First},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ def test_features(api, wiki):
 
 
 def test_bib(api):
-    assert len(api.bib) == 6
+    assert len(api.bib) == 7
 
 
 def test_sheets(api):

--- a/tests/test_srctok.py
+++ b/tests/test_srctok.py
@@ -45,6 +45,11 @@ def test_source_to_refs_disambiguation_by_title(bibs_and_lgks):
     assert source_to_refs('Author nd', 'abc', bibs, lgks, unresolved)[0] == [('bookc', [])]
 
 
+def test_source_to_refs_ignore_via_clauses(bibs_and_lgks):
+    bibs, lgks = bibs_and_lgks
+    assert source_to_refs('OtherGuy 1972 via Author 2022', 'abc', bibs, lgks, Counter())[0] == [('book2022', [])]
+
+
 def test_misc():
     assert allmax({}) == {}
 


### PR DESCRIPTION
This allows for stuff like `B 2021 via A 2022` in sources (`sourcelookup` will only try to look up A 2022).

Question is:  What should we do about the data sheets where the `via` clauses have been moved out to one of the comment fields (can't remember which rn).  Should we just leave them be or should we reintegrate the `via` thing into the `Sources` column? (intuitively this shouldn't be hard to do -- feels very grep'able).