### PR TITLE
sourcelookup: allow more than one input sheet (cf. #70)

### DIFF
--- a/src/pygrambank/commands/sourcelookup.py
+++ b/src/pygrambank/commands/sourcelookup.py
@@ -8,7 +8,7 @@ from termcolor import colored
 from cldfcatalog import Catalog
 
 from pygrambank.sheet import Sheet
-from pygrambank.cldf import refs
+from pygrambank.cldf import refs, Glottolog, Bibs, languoid_id_map
 
 
 def register(parser):
@@ -19,8 +19,9 @@ def register(parser):
         type=pathlib.Path,
     )
     parser.add_argument(
-        'sheet',
+        'sheets',
         type=pathlib.Path,
+        nargs='+',
     )
     parser.add_argument(
         '--glottolog-version',
@@ -38,29 +39,49 @@ def run(args):
 
 
 def run_(args, glottolog):  # pragma: no cover
-    sources, unresolved, lgks = refs(args.repos, glottolog, Sheet(args.sheet))
-    seen = collections.defaultdict(list)
-    print(colored('Resolved sources:', attrs=['bold']))
-    for src in sources:
-        seen[src.id].append(src)
-    for srcid, srcs in seen.items():
-        print('{}\t{}\t{}'.format(len(srcs), srcid, srcs[0]))
-    if unresolved:
-        print()
-        print(colored('Unresolved sources:', attrs=['bold']))
-        for spec, v in unresolved.most_common():
-            try:
-                author, year, code = spec
-                print('{}\t{} {}'.format(v, author, year))
-            except ValueError:
-                print(spec)
-        if lgks:
+    sheets = [Sheet(sh) for sh in args.sheets]
+
+    print('Reading languoid ids from Glottolog...')
+    glottolog = Glottolog(glottolog)
+    id_to_glottocode = languoid_id_map(glottolog, [s.glottocode for s in sheets])
+
+    print('Loading bibliography...')
+    bibs = Bibs(glottolog, args.repos)
+
+    keys_by_glottocode = collections.defaultdict(set)
+    for key, code in bibs.iter_codes():
+        if code in id_to_glottocode:
+            keys_by_glottocode[id_to_glottocode[code]].add(key)
+
+    for sheet in sheets:
+        print(colored(
+            '\nSource look-up for sheet {}...\n'.format(sheet.path),
+            attrs=['bold']))
+        sources, unresolved, lgks = refs(
+            args.repos, sheet.glottocode, bibs, keys_by_glottocode, sheet)
+
+        seen = collections.defaultdict(list)
+        print(colored('Resolved sources:', attrs=['bold']))
+        for src in sources:
+            seen[src.id].append(src)
+        for srcid, srcs in seen.items():
+            print('{}\t{}\t{}'.format(len(srcs), srcid, srcs[0]))
+        if unresolved:
             print()
-            print(colored('Available sources:', attrs=['bold']))
-            for (k, t, a, y) in lgks:
-                print('{}\t{}\t{}'.format(
-                    colored(k, color='blue'),
-                    t,
-                    colored('{} {}'.format(a, y), attrs=['bold'])))
-    print()
-    print(colored('FAIL' if unresolved else 'OK', color='red' if unresolved else 'green'))
+            print(colored('Unresolved sources:', attrs=['bold']))
+            for spec, v in unresolved.most_common():
+                try:
+                    author, year, code = spec
+                    print('{}\t{} {}'.format(v, author, year))
+                except ValueError:
+                    print(spec)
+            if lgks:
+                print()
+                print(colored('Available sources:', attrs=['bold']))
+                for (k, t, a, y) in lgks:
+                    print('{}\t{}\t{}'.format(
+                        colored(k, color='blue'),
+                        t,
+                        colored('{} {}'.format(a, y), attrs=['bold'])))
+        print()
+        print(colored('FAIL' if unresolved else 'OK', color='red' if unresolved else 'green'))


### PR DESCRIPTION
`grambank sourcelookup` now takes more than one data sheet as its argument, so
one can process multiple sheets, while only having to wait for the bibliography
to load once.

@HedvigS About your idea of reading the file paths from a txt file:  You can still do that by running `grambank` through [xargs(1)][xargs].

    $ xargs grambank sourcelookup path-to-glottolog-repo < list-of-files.txt

[xargs]: https://www.freebsd.org/cgi/man.cgi?query=xargs&apropos=0&sektion=0&manpath=FreeBSD+13.1-RELEASE+and+Ports&arch=default&format=html

Only downside is that you have to escape all spaces within the file names, e.g.:

    /home/User\ Name/Desktop/My\ Data\ Sheets/XYZ_abcd1234.tsv
    /home/User\ Name/Desktop/My\ Data\ Sheets/ABC_xyzw1234.tsv
