### PR TITLE
Replace `logging` call with `print()`.

### DIFF
--- a/src/pygrambank/srctok.py
+++ b/src/pygrambank/srctok.py
@@ -1,5 +1,4 @@
 import re
-import logging
 from termcolor import colored
 from itertools import groupby
 
@@ -136,7 +135,7 @@ def iter_key_pages(lg, ayp, e, lgks):
     if not matched:
         if ayp not in UNMATCHED:
             print(colored('PARTIAL FAIL', color='red'))
-            logging.getLogger(__name__).warning('unmatched ref: {}'.format(ayp))
+            print('WARNING: unmatched reference: {}'.format(ayp))
             UNMATCHED.add(ayp)
 
 


### PR DESCRIPTION
This is the only place in the entire package where we use `logging` instead of `print()` for logging.  It is also the only place in this package that prints to stderr instead of stdout which means these messages don't always show up where they're supposed to…

I'd opt following for the path of least resistance and just go full `print()`.

EDIT: typo
EDIT 2: fixed the wrong thing wrongly (<_<)"