### PR TITLE
Bibmatcher confused about field notes

### DIFF
--- a/src/pygrambank/bib.py
+++ b/src/pygrambank/bib.py
@@ -211,6 +211,24 @@ def prioritised_bibkeys(bibkeys, bibliography_entries):
     return prioritised_bibkeys
 
 
+def is_unpublished(source_string):
+    return (
+        'p.c' in source_string
+        or 'personal communication' in source_string
+        or 'pers comm' in source_string
+        or 'pers. comm' in source_string
+        or 'ieldnotes' in source_string
+        or 'ield notes' in source_string
+        or 'forth' in source_string
+        or 'Forth' in source_string
+        or 'ubmitted' in source_string
+        or 'o appear' in source_string
+        or 'in press' in source_string
+        or 'in prep' in source_string
+        or 'in prog' in source_string
+        or source_string.startswith('http'))
+
+
 def mismatch_is_fatal(source_string):
     """Return True iff. an unmatched source string constitutes an error.
 
@@ -225,22 +243,7 @@ def mismatch_is_fatal(source_string):
         #     '[%s] default source:%s' % (glottocode, source_string),
         #     glottocode)
         return False
-    elif (
-        'p.c' in source_string
-        or 'personal communication' in source_string
-        or 'pers comm' in source_string
-        or 'pers. comm' in source_string
-        or 'ieldnotes' in source_string
-        or 'ield notes' in source_string
-        or 'forth' in source_string
-        or 'Forth' in source_string
-        or 'ubmitted' in source_string
-        or 'o appear' in source_string
-        or 'in press' in source_string
-        or 'in prep' in source_string
-        or 'in prog' in source_string
-        or source_string.startswith('http')
-    ):
+    elif is_unpublished(source_string):
         return False
     else:
         return True
@@ -256,7 +259,7 @@ def iter_authoryearpages(source_string):
      * Word from title
     """
     for citation_string in source_string.replace("), ", "); ").split(";"):
-        if "p.c." in citation_string:
+        if is_unpublished(citation_string):
             continue
         condensed = False
         citation_string = citation_string.strip()

--- a/src/pygrambank/bib.py
+++ b/src/pygrambank/bib.py
@@ -234,19 +234,14 @@ def mismatch_is_fatal(source_string):
 
     i.e., ignore stuff like Smith (personal communication).
     """
-    # Note: In theory this code could be combined into one big boolean
-    # expression but I doubt that will it any more readable...
-    if REGEX_ONLY_PAGES.match(source_string):
-        # TODO: Maybe find a way to warn about this
-        # print(
-        #     'PAGEONLY:',
-        #     '[%s] default source:%s' % (glottocode, source_string),
-        #     glottocode)
-        return False
-    elif is_unpublished(source_string):
-        return False
-    else:
-        return True
+    # TODO: Maybe find a way to warn about page numbers
+    # print(
+    #     'PAGEONLY:',
+    #     '[%s] default source:%s' % (glottocode, source_string),
+    #     glottocode)
+    return not (
+        REGEX_ONLY_PAGES.match(source_string)
+        or is_unpublished(source_string))
 
 
 def iter_authoryearpages(source_string):

--- a/tests/test_bib_matcher.py
+++ b/tests/test_bib_matcher.py
@@ -85,6 +85,26 @@ def test_ignore_personal_comm():
     assert 'source not confirmed' not in row.Source_comment
 
 
+def test_ignore_field_notes_without_year():
+    bib_matcher = BibliographyMatcher(BIBLIOGRAPHY, BIBKEYS_BY_GLOTTOCODE)
+    row = Row(None, None, 'Beenthere (field notes)')
+    bib_matcher.add_resolved_citation_to_row(ENGLISH, row)
+    assert not bib_matcher.has_sources()
+    assert not bib_matcher.has_unresolved_citations()
+    assert row.has_valid_source()
+    assert 'source not confirmed' not in row.Source_comment
+
+
+def test_ignore_field_notes_with_year():
+    bib_matcher = BibliographyMatcher(BIBLIOGRAPHY, BIBKEYS_BY_GLOTTOCODE)
+    row = Row(None, None, 'Beenthere (field notes 2006)')
+    bib_matcher.add_resolved_citation_to_row(ENGLISH, row)
+    assert not bib_matcher.has_sources()
+    assert not bib_matcher.has_unresolved_citations()
+    assert row.has_valid_source()
+    assert 'source not confirmed' not in row.Source_comment
+
+
 def test_ignore_empty_source():
     bib_matcher = BibliographyMatcher(BIBLIOGRAPHY, BIBKEYS_BY_GLOTTOCODE)
     row = Row(None, None, '')


### PR DESCRIPTION
 * Bibliography code ignores stuff like *Smith (personal communication)* automatically
 * This includes stuff like *Smith (field notes)*
 * That didn't work properly  when there was a year attached to it, like *Smith (field notes 2012)*.
 * It does now.