### PR TITLE
KeyError for binarised features during makecldf.

### DIFF
--- a/src/pygrambank/api.py
+++ b/src/pygrambank/api.py
@@ -43,11 +43,11 @@ class Grambank(API):
 
     @lazyproperty
     def ordered_features(self):
-        return list(self.gb20.iterfeatures(self.wiki))
+        return list(self.features.values())
 
     @lazyproperty
     def features(self):
-        return collections.OrderedDict([(f['Grambank ID'], f) for f in self.ordered_features])
+        return self.gb20.read_features(self.wiki)
 
     @lazyproperty
     def issues_path(self):

--- a/src/pygrambank/commands/new.py
+++ b/src/pygrambank/commands/new.py
@@ -20,18 +20,10 @@ def register(parser):
 
 
 def normalised_summary(feature_dict, feature):
-    summary = parent_wiki_get(feature_dict, feature, 'Summary') or ''
+    summary = feature.wiki.get('Summary') or ''
     summary = summary.replace('\n', ' ')
     summary = summary.replace('\t', ' ')
     return summary
-
-
-def parent_wiki_get(feature_dict, feature, key):
-    parent = feature.get('Multistate_parent')
-    if parent and parent in feature_dict:
-        return feature_dict[parent].wiki.get(key) or feature.wiki.get(key)
-    else:
-        return feature.wiki.get(key)
 
 
 def assemble_row(row_spec, feature):
@@ -64,7 +56,7 @@ def run(args):
         ('Contributed_Datapoints', lambda f: ''),
         ('Clarifying comments', lambda f: normalised_summary(features, f)),
         ('Relevant unit(s)', lambda f: f['Relevant unit(s)']),
-        ('Patron', lambda f: parent_wiki_get(features, f, 'Patron')),
+        ('Patron', lambda f: f.wiki_or_gb20('Patron', 'Feature Patron')),
     ])
 
     with UnicodeWriter(name, delimiter='\t') as w:


### PR DESCRIPTION
Binarised features inherit their *Clarifying Comment* from their parent features.  However, the inheritance was implemented too late which means the features raised a `KeyError` when running `makecldf`.

This patch copies the parent values right when the features are loaded from disk.