### PR TITLE
Drop multistate features from template

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/pygrambank/commands/new.py
+++ b/src/pygrambank/commands/new.py
@@ -2,7 +2,6 @@
 Create a new, empty sheet
 """
 import pathlib
-import collections
 
 from csvw.dsv import UnicodeWriter
 
@@ -41,24 +40,24 @@ def run(args):
     else:
         name = pathlib.Path(args.out)
 
-    features = collections.OrderedDict(
-        (f.id, f)
+    features = {
+        f.id: f
         for f in args.repos.features.values()
-        if f.get('Binary_Multistate') != 'multi')
+        if f.get('Binary_Multistate') != 'multi'}
 
-    row_spec = collections.OrderedDict([
-        ('Feature_ID', lambda f: f.id),
-        ('Feature', lambda f: f.wiki_or_gb20('title', 'Feature')),
-        ('Possible Values', lambda f: f['Possible Values']),
-        ('Language_ID', lambda f: ''),
-        ('Value', lambda f: ''),
-        ('Source', lambda f: ''),
-        ('Comment', lambda f: ''),
-        ('Contributed_Datapoints', lambda f: ''),
-        ('Clarifying comments', lambda f: normalised_summary(features, f)),
-        ('Relevant unit(s)', lambda f: f['Relevant unit(s)']),
-        ('Patron', lambda f: f.wiki_or_gb20('Patron', 'Feature Patron')),
-    ])
+    row_spec = {
+        'Feature_ID': lambda f: f.id,
+        'Feature': lambda f: f.wiki_or_gb20('title', 'Feature'),
+        'Possible Values': lambda f: f['Possible Values'],
+        'Language_ID': lambda f: '',
+        'Value': lambda f: '',
+        'Source': lambda f: '',
+        'Comment': lambda f: '',
+        'Contributed_Datapoints': lambda f: '',
+        'Clarifying comments': lambda f: normalised_summary(features, f),
+        'Relevant unit(s)': lambda f: f['Relevant unit(s)'],
+        'Patron': lambda f: f.wiki_or_gb20('Patron', 'Feature Patron'),
+    }
 
     with UnicodeWriter(name, delimiter='\t') as w:
         w.writerow(row_spec)

--- a/src/pygrambank/commands/new.py
+++ b/src/pygrambank/commands/new.py
@@ -43,7 +43,8 @@ def run(args):
 
     features = collections.OrderedDict(
         (f.id, f)
-        for f in args.repos.features.values())
+        for f in args.repos.features.values()
+        if f.get('Binary_Multistate') != 'multi')
 
     row_spec = collections.OrderedDict([
         ('Feature_ID', lambda f: f.id),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Dropping the multi-state features from the data sheet template to incentivise coders to fill out the binarised versions instead.