### PR TITLE
Check for conflicting binarisation

### DIFF
--- a/src/pygrambank/sheet.py
+++ b/src/pygrambank/sheet.py
@@ -130,7 +130,7 @@ def check_feature_dependencies(rows):
                 and _value(binary_b) == bad_b
             ):
                 errors.append(
-                    "{} cant't be {} if {} is {} and {} is {}".format(
+                    "{} can't be {} if {} is {} and {} is {}".format(
                         parent, bad_parent,
                         binary_a, bad_a,
                         binary_b, bad_b))

--- a/src/pygrambank/sheet.py
+++ b/src/pygrambank/sheet.py
@@ -73,7 +73,7 @@ def check_feature_dependencies(rows):
     if (_value('GB265')
         == _value('GB266')
         == _value('GB273')
-        == 0
+        == '0'
     ):
         reason = 'GB265, GB266, and GB273 are all 0'
         _require_comment('GB265', reason)
@@ -84,13 +84,13 @@ def check_feature_dependencies(rows):
         == _value('GB073')
         == _value('GB074')
         == _value('GB075')
-        == 0
+        == '0'
     ):
         reason = 'GB072, GB073, GB074, and GB075 are all 0'
         _require_comment('GB074', reason)
         _require_comment('GB075', reason)
 
-    if _value('GB155') == 1 and _value('GB113') == 0:
+    if _value('GB155') == '1' and _value('GB113') == '0':
         reason = 'GB155 is 1 and GB113 is 0'
         _require_comment('GB155', reason)
         _require_comment('GB113', reason)

--- a/src/pygrambank/sheet.py
+++ b/src/pygrambank/sheet.py
@@ -106,8 +106,8 @@ def check_feature_dependencies(rows):
         ('GB025', 'GB025a', 'GB025b', 3),
         ('GB065', 'GB065a', 'GB065b', 3),
         ('GB130', 'GB130a', 'GB130b', 3),
-        ('GB193', 'GB193a', 'GB193b', 3),
         # four states
+        ('GB193', 'GB193a', 'GB193b', 4),
         ('GB203', 'GB203a', 'GB203b', 4)]
     bad_vals_ternary = [
         ('1', '0', '0'),

--- a/src/pygrambank/sheet.py
+++ b/src/pygrambank/sheet.py
@@ -19,7 +19,7 @@ def check_feature_dependencies(rows):
         row = values.get(feat)
         return row.Value if row else None
 
-    def _comment(feat):   # pragma: nocover
+    def _comment(feat):
         row = values.get(feat)
         return row.Comment if row else None
 
@@ -34,14 +34,14 @@ def check_feature_dependencies(rows):
         == _value('GB410')
         == '0'
     ):
-        errors.append("GB408, GB409, and GB410 can't all be 0")  # pragma: nocover
+        errors.append("GB408, GB409, and GB410 can't all be 0")
 
     if (_value('GB131')
         == _value('GB132')
         == _value('GB133')
         == '0'
     ):
-        errors.append("GB131, GB132, and GB133 can't all be 0")  # pragma: nocover
+        errors.append("GB131, GB132, and GB133 can't all be 0")
 
     if (_value('GB083')
         == _value('GB084')
@@ -60,7 +60,7 @@ def check_feature_dependencies(rows):
         == '0'
     ):
         reason = 'GB333, GB334, GB335, and GB336 are all 0'
-        for feat in ('GB333', 'GB334', 'GB335', 'GB336'):  # pragma: nocover
+        for feat in ('GB333', 'GB334', 'GB335', 'GB336'):
             _require_comment(feat, reason)
 
     for feat in (
@@ -68,7 +68,7 @@ def check_feature_dependencies(rows):
         'GB260', 'GB165', 'GB319'
     ):
         if _value(feat) == '1':
-            _require_comment(feat, reason='it is coded 1')  # pragma: nocover
+            _require_comment(feat, reason='it is coded 1')
 
     if (_value('GB265')
         == _value('GB266')
@@ -99,6 +99,47 @@ def check_feature_dependencies(rows):
         reason = 'GB022 and GB023 are both 1'
         _require_comment('GB022', reason)
         _require_comment('GB023', reason)
+
+    multistate_features = [
+        # three states
+        ('GB024', 'GB024a', 'GB024b', 3),
+        ('GB025', 'GB025a', 'GB025b', 3),
+        ('GB065', 'GB065a', 'GB065b', 3),
+        ('GB130', 'GB130a', 'GB130b', 3),
+        ('GB193', 'GB193a', 'GB193b', 3),
+        # four states
+        ('GB203', 'GB203a', 'GB203b', 4)]
+    bad_vals_ternary = [
+        ('1', '0', '0'),
+        ('1', '1', '1'),
+        ('2', '1', '1'),
+        ('2', '0', '0'),
+        ('3', '0', '1'),
+        ('3', '1', '0')]
+    bad_vals_quarternary = [
+        ('0', '1', '0'),
+        ('0', '0', '1')]
+    for parent, binary_a, binary_b, n_states in multistate_features:
+        if n_states < 4:
+            vals = bad_vals_ternary
+        else:
+            vals = itertools.chain(bad_vals_ternary, bad_vals_quarternary)
+        for bad_parent, bad_a, bad_b in vals:
+            if (_value(parent) == bad_parent
+                and _value(binary_a) == bad_a
+                and _value(binary_b) == bad_b
+            ):
+                errors.append(
+                    "{} cant't be {} if {} is {} and {} is {}".format(
+                        parent, bad_parent,
+                        binary_a, bad_a,
+                        binary_b, bad_b))
+
+        if (n_states < 4
+            and _value(binary_a) == '0'
+            and _value(binary_b) == '0'
+        ):
+            errors.append(f"{binary_a} and {binary_b} can't both be 0")
 
     return errors
 

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -226,8 +226,7 @@ class FeatureDependencies(unittest.TestCase):
             ('GB024', 'GB024a', 'GB024b'),
             ('GB025', 'GB025a', 'GB025b'),
             ('GB065', 'GB065a', 'GB065b'),
-            ('GB130', 'GB130a', 'GB130b'),
-            ('GB193', 'GB193a', 'GB193b')]
+            ('GB130', 'GB130a', 'GB130b')]
         good_vals = [
             ('1', '?', '0'),
             ('1', '1', '?'),
@@ -274,6 +273,7 @@ class FeatureDependencies(unittest.TestCase):
 
     def test_four_state_features(self):
         features = [
+            ('GB193', 'GB193a', 'GB193b'),
             ('GB203', 'GB203a', 'GB203b')]
         good_vals = [
             ('0', '?', '0'),

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -221,6 +221,108 @@ class FeatureDependencies(unittest.TestCase):
         self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 2)
         self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
 
+    def test_three_state_features(self):
+        features = [
+            ('GB024', 'GB024a', 'GB024b'),
+            ('GB025', 'GB025a', 'GB025b'),
+            ('GB065', 'GB065a', 'GB065b'),
+            ('GB130', 'GB130a', 'GB130b'),
+            ('GB193', 'GB193a', 'GB193b')]
+        good_vals = [
+            ('1', '?', '0'),
+            ('1', '1', '?'),
+            ('1', '1', '0'),
+            ('2', '?', '1'),
+            ('2', '0', '?'),
+            ('2', '0', '1'),
+            ('3', '?', '1'),
+            ('3', '1', '?'),
+            ('3', '1', '1')]
+        bad_vals = [
+            ('0', '0', '0'),
+            ('1', '0', '0'),
+            ('1', '1', '1'),
+            ('2', '1', '1'),
+            ('2', '0', '0'),
+            ('3', '0', '1'),
+            ('3', '1', '0')]
+        for parent, binary_a, binary_b in features:
+            for val_parent, val_a, val_b in good_vals:
+                good_rows = [
+                    self.row(parent, val_parent),
+                    self.row(binary_a, val_a),
+                    self.row(binary_b, val_b)]
+                self.assertEqual(
+                    len(sheet.check_feature_dependencies(good_rows)),
+                    0,
+                    '{}={}; {}={}; {}={}'.format(
+                        parent, val_parent,
+                        binary_a, val_a,
+                        binary_b, val_b))
+            for val_parent, val_a, val_b in bad_vals:
+                bad_rows = [
+                    self.row(parent, val_parent),
+                    self.row(binary_a, val_a),
+                    self.row(binary_b, val_b)]
+                self.assertGreater(
+                    len(sheet.check_feature_dependencies(bad_rows)),
+                    0,
+                    '{}={}; {}={}; {}={}'.format(
+                        parent, val_parent,
+                        binary_a, val_a,
+                        binary_b, val_b))
+
+    def test_four_state_features(self):
+        features = [
+            ('GB203', 'GB203a', 'GB203b')]
+        good_vals = [
+            ('0', '?', '0'),
+            ('0', '0', '?'),
+            ('0', '0', '0'),
+            ('1', '?', '0'),
+            ('1', '1', '?'),
+            ('1', '1', '0'),
+            ('2', '?', '1'),
+            ('2', '0', '?'),
+            ('2', '0', '1'),
+            ('3', '?', '1'),
+            ('3', '1', '?'),
+            ('3', '1', '1')]
+        bad_vals = [
+            ('0', '1', '0'),
+            ('0', '0', '1'),
+            ('1', '0', '0'),
+            ('1', '1', '1'),
+            ('2', '1', '1'),
+            ('2', '0', '0'),
+            ('3', '0', '1'),
+            ('3', '1', '0')]
+        for parent, binary_a, binary_b in features:
+            for val_parent, val_a, val_b in good_vals:
+                good_rows = [
+                    self.row(parent, val_parent),
+                    self.row(binary_a, val_a),
+                    self.row(binary_b, val_b)]
+                self.assertEqual(
+                    len(sheet.check_feature_dependencies(good_rows)),
+                    0,
+                    '{}={}; {}={}; {}={}'.format(
+                        parent, val_parent,
+                        binary_a, val_a,
+                        binary_b, val_b))
+            for val_parent, val_a, val_b in bad_vals:
+                bad_rows = [
+                    self.row(parent, val_parent),
+                    self.row(binary_a, val_a),
+                    self.row(binary_b, val_b)]
+                self.assertGreater(
+                    len(sheet.check_feature_dependencies(bad_rows)),
+                    0,
+                    '{}={}; {}={}; {}={}'.format(
+                        parent, val_parent,
+                        binary_a, val_a,
+                        binary_b, val_b))
+
 
 @pytest.mark.filterwarnings("ignore:Duplicate")
 @pytest.mark.parametrize(

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -1,4 +1,5 @@
 import pathlib
+import unittest
 
 import pytest
 
@@ -36,6 +37,189 @@ def test_visitor(sheet_abbr):
 def test_check(api, sheet_abbr, sheet_factory, capsys):
     assert sheet_abbr.check(api) >\
            sheet.Sheet(api.sheets_dir / 'NOVALS_abcd1234.tsv').check(api)
+
+
+class FeatureDependencies(unittest.TestCase):
+
+    def row(self, feature_id, value, comment=None):
+        return sheet.Row(
+            Feature_ID=feature_id,
+            Value=value,
+            Source='',
+            Comment=comment or '')
+
+    def test_gb408_to_410(self):
+        good_rows = [
+            self.row('GB408', '0'),
+            self.row('GB409', '0'),
+            self.row('GB410', '1')]
+        bad_rows = [
+            self.row('GB408', '0'),
+            self.row('GB409', '0'),
+            self.row('GB410', '0')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 1)
+
+    def test_gb131_to_133(self):
+        good_rows = [
+            self.row('GB131', '0'),
+            self.row('GB132', '0'),
+            self.row('GB133', '1')]
+        bad_rows = [
+            self.row('GB131', '0'),
+            self.row('GB132', '0'),
+            self.row('GB133', '0')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 1)
+
+    def test_gb309(self):
+        good_rows = [
+            self.row('GB083', '0'),
+            self.row('GB084', '0'),
+            self.row('GB121', '0'),
+            self.row('GB521', '1'),
+            self.row('GB309', '1')]
+        bad_rows = [
+            self.row('GB083', '0'),
+            self.row('GB084', '0'),
+            self.row('GB121', '0'),
+            self.row('GB521', '0'),
+            self.row('GB309', '1')]
+        fixed_rows = [
+            self.row('GB083', '0'),
+            self.row('GB084', '0'),
+            self.row('GB121', '0'),
+            self.row('GB521', '0'),
+            self.row('GB309', '1', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 1)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
+
+    def test_gb333_to_336(self):
+        good_rows = [
+            self.row('GB333', '1'),
+            self.row('GB334', '0'),
+            self.row('GB335', '0'),
+            self.row('GB336', '0')]
+        bad_rows = [
+            self.row('GB333', '0'),
+            self.row('GB334', '0'),
+            self.row('GB335', '0'),
+            self.row('GB336', '0')]
+        fixed_rows = [
+            self.row('GB333', '0', 'comment'),
+            self.row('GB334', '0', 'comment'),
+            self.row('GB335', '0', 'comment'),
+            self.row('GB336', '0', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 4)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
+
+    def test_comments_in_various_features(self):
+        good_rows = [
+            self.row('GB026', '0'),
+            self.row('GB129', '0'),
+            self.row('GB165', '0'),
+            self.row('GB166', '0'),
+            self.row('GB197', '0'),
+            self.row('GB260', '0'),
+            self.row('GB285', '0'),
+            self.row('GB303', '0'),
+            self.row('GB319', '0'),
+            self.row('GB320', '0'),
+            self.row('GB336', '0')]
+        bad_rows = [
+            self.row('GB026', '1'),
+            self.row('GB129', '1'),
+            self.row('GB165', '1'),
+            self.row('GB166', '1'),
+            self.row('GB197', '1'),
+            self.row('GB260', '1'),
+            self.row('GB285', '1'),
+            self.row('GB303', '1'),
+            self.row('GB319', '1'),
+            self.row('GB320', '1'),
+            self.row('GB336', '1')]
+        fixed_rows = [
+            self.row('GB026', '1', 'comment'),
+            self.row('GB129', '1', 'comment'),
+            self.row('GB165', '1', 'comment'),
+            self.row('GB166', '1', 'comment'),
+            self.row('GB197', '1', 'comment'),
+            self.row('GB260', '1', 'comment'),
+            self.row('GB285', '1', 'comment'),
+            self.row('GB303', '1', 'comment'),
+            self.row('GB319', '1', 'comment'),
+            self.row('GB320', '1', 'comment'),
+            self.row('GB336', '1', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 11)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
+
+    def test_gb265_266_274(self):
+        good_rows = [
+            self.row('GB265', '1'),
+            self.row('GB266', '0'),
+            self.row('GB273', '0')]
+        bad_rows = [
+            self.row('GB265', '0'),
+            self.row('GB266', '0'),
+            self.row('GB273', '0')]
+        fixed_rows = [
+            self.row('GB265', '0', 'comment'),
+            self.row('GB266', '0', 'comment'),
+            self.row('GB273', '0', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 3)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
+
+    def test_gb072_to_075(self):
+        good_rows = [
+            self.row('GB072', '1'),
+            self.row('GB073', '0'),
+            self.row('GB074', '0'),
+            self.row('GB075', '0')]
+        bad_rows = [
+            self.row('GB072', '0'),
+            self.row('GB073', '0'),
+            self.row('GB074', '0'),
+            self.row('GB075', '0')]
+        fixed_rows = [
+            self.row('GB072', '0'),
+            self.row('GB073', '0'),
+            self.row('GB074', '0', 'comment'),
+            self.row('GB075', '0', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 2)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
+
+    def test_gb155_and_133(self):
+        good_rows = [
+            self.row('GB113', '0'),
+            self.row('GB155', '0')]
+        bad_rows = [
+            self.row('GB113', '0'),
+            self.row('GB155', '1')]
+        fixed_rows = [
+            self.row('GB113', '0', 'comment'),
+            self.row('GB155', '1', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 2)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
+
+    def test_gb022_and_023(self):
+        good_rows = [
+            self.row('GB022', '0'),
+            self.row('GB023', '1')]
+        bad_rows = [
+            self.row('GB022', '1'),
+            self.row('GB023', '1')]
+        fixed_rows = [
+            self.row('GB022', '1', 'comment'),
+            self.row('GB023', '1', 'comment')]
+        self.assertEqual(len(sheet.check_feature_dependencies(good_rows)), 0)
+        self.assertEqual(len(sheet.check_feature_dependencies(bad_rows)), 2)
+        self.assertEqual(len(sheet.check_feature_dependencies(fixed_rows)), 0)
 
 
 @pytest.mark.filterwarnings("ignore:Duplicate")


### PR DESCRIPTION
Work on feature checks:

 * Add unit tests for all the existing feature checks.
 * Fix a few checks where I checked for the *integer* 0 instead of the *string* ‘0’.
 * Check if binarised features match up.
 * Complain when binarised *ternary* features are both 0.